### PR TITLE
Add support for cross-compiling to darwin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ __pycache__/
 .favorites.json
 /*-*-*-*/
 /*-*-*/
-/Makefile
 /build
 /config.toml
 /dist/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+.PHONY: compile
+compile:
+	docker run --rm -it \
+		-v $(PWD):/mlc \
+		-w /mlc \
+		joseluisq/rust-linux-darwin-builder:1.45.1 \
+		make cross-compile
+
+.PHONY: cross-compile
+cross-compile:
+	@echo
+	@echo "1. Cross compiling"
+	@rustc -vV
+	@echo
+	@echo "2. Compiling application (linux-musl x86_64)..."
+	@cargo build --release --target x86_64-unknown-linux-musl
+	@du -sh target/x86_64-unknown-linux-musl/release/mlc
+	@echo
+	@echo "3. Compiling application (apple-darwin x86_64)..."
+	@cargo build --release --target x86_64-apple-darwin
+	@du -sh target/x86_64-apple-darwin/release/mlc


### PR DESCRIPTION
Using https://github.com/joseluisq/rust-linux-darwin-builder I was able to get support for building Darwin binaries to work. Added a Makefile, I'm not sure if there's an easy way to do the same with Cargo.

`make compile` launches the docker image, which then run `make cross-compile` in the image. You end up with `target/x86_64-apple-darwin/release/mlc` and `target/x86_64-unknown-linux-musl/release/mlc`.

I'm hoping to use this tool for my project's Markdown linting on dev machines, people use both OSX and Linux so hoping to have released binaries for each.