### PR TITLE
Bug: unable to extract link if on the same line as inline code block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Types for Changes:
 
 * Changed throttle for increased performance
 * Security upgraded external dependencies
+* Fixed #33 link not found near code block
 
 ## [0.14.2] - 2021-03-13
 

--- a/src/link_extractors/markdown_link_extractor.rs
+++ b/src/link_extractors/markdown_link_extractor.rs
@@ -31,7 +31,7 @@ fn forward_until_matching(vector: &Vec<char>, pos: &mut usize) -> bool {
 
         // keep track of any new start_chars we find so we know when we've found
         // a char that matches our first start_char
-        if vector.get(*pos) == start_char {
+        if vector.get(*pos) == start_char && matching_char != start_char{
             num_unmatched_start_chars += 1;
         }
         if vector.get(*pos) == matching_char {
@@ -549,12 +549,34 @@ mod tests {
     #[test]
     fn forward_until_matching_find_match() {
         let vector = vec![
-            '(', 'h', 'e', 'l', 'l', 'o', ' ', '(', 'w', ')', 'o', 'r', 'l', 'd', ')',
+            '(', 'h', 'e', 'l', 'l', 'o', ' ', '(', 'w', ')', 'o', 'r', 'l', 'd', ')', ':', ')',
         ];
         let mut pos = 0;
         let matching = forward_until_matching(&vector, &mut pos);
         assert_eq!(pos, 14);
         assert!(matching);
         assert_eq!(vector[pos], ')');
+    }    
+
+    #[test]
+    fn forward_until_matching_issue_33() {
+        let vector = vec![
+            '`', 'b', 'u', 'g', '`', ' ', '[', 'c', 'o', 'd', 'e', ']'
+        ];
+        let mut pos = 0;
+        let matching = forward_until_matching(&vector, &mut pos);
+        assert_eq!(pos, 4);
+        assert!(matching);
+        assert_eq!(vector[pos], '`');
+    }
+
+    #[test]
+    fn forward_until_matching_no_match() {
+        let vector = vec![
+            '`', 'b', 'u', 'g', '`', ' ', '[', 'c', 'o', 'd', 'e', ']'
+        ];
+        let mut pos = 4;
+        let matching = forward_until_matching(&vector, &mut pos);
+        assert!(!matching);
     }
 }

--- a/src/link_extractors/markdown_link_extractor.rs
+++ b/src/link_extractors/markdown_link_extractor.rs
@@ -11,17 +11,6 @@ fn skip_whitespace(vector: &Vec<char>, pos: &mut usize) {
 
 /// Advance the `pos` index in the vector until reaching a character that
 /// matches the character at the index `pos` began at.
-///
-/// # Examples
-///
-/// ```ignore
-/// let vector = vec!['(', 'h', 'e', 'l', 'l', 'o', ' ', '(', 'w', ')', 'o', 'r', 'l', 'd', ')'];
-/// let pos = 0;
-///
-/// let matching_char = forward_until_matching(&vector, &mut pos);
-/// assert_eq!(pos, 14);
-/// assert_eq!(matching_char, ')');
-/// ```
 fn forward_until_matching(vector: &Vec<char>, pos: &mut usize) -> bool {
     let start_char = vector.get(*pos);
     let matching_char = match start_char {
@@ -555,5 +544,17 @@ mod tests {
             source: "".to_string(),
         };
         assert_eq!(vec![expected], result);
+    }
+
+    #[test]
+    fn forward_until_matching_find_match() {
+        let vector = vec![
+            '(', 'h', 'e', 'l', 'l', 'o', ' ', '(', 'w', ')', 'o', 'r', 'l', 'd', ')',
+        ];
+        let mut pos = 0;
+        let matching = forward_until_matching(&vector, &mut pos);
+        assert_eq!(pos, 14);
+        assert!(matching);
+        assert_eq!(vector[pos], ')');
     }
 }

--- a/src/link_extractors/markdown_link_extractor.rs
+++ b/src/link_extractors/markdown_link_extractor.rs
@@ -392,6 +392,20 @@ mod tests {
     }
 
     #[test]
+    fn link_near_inline_code() {
+        let le = MarkdownLinkExtractor();
+        let input = format!(" `bug` [code](http://example.net/), link!.");
+        let result = le.find_links(&input);
+        let expected = MarkupLink {
+            target: "http://example.net/".to_string(),
+            line: 1,
+            column: 14,
+            source: "".to_string(),
+        };
+        assert_eq!(vec![expected], result);
+    }
+
+    #[test]
     fn code_block() {
         let le = MarkdownLinkExtractor();
         let input = format!(" ``` js\n[code](http://example.net/)```, no link!.");

--- a/src/link_extractors/markdown_link_extractor.rs
+++ b/src/link_extractors/markdown_link_extractor.rs
@@ -96,6 +96,7 @@ impl LinkExtractor for MarkdownLinkExtractor {
                 match line_chars[column] {
                     '`' => {
                         forward_until_matching(&line_chars, &mut column);
+                        column += 1; // Forward to next char after `
                     }
                     '\\' => {
                         column += 1; // Escape next character
@@ -389,6 +390,20 @@ mod tests {
             target: "http://example.net/".to_string(),
             line: 1,
             column: 14,
+            source: "".to_string(),
+        };
+        assert_eq!(vec![expected], result);
+    }
+
+    #[test]
+    fn link_very_near_inline_code() {
+        let le = MarkdownLinkExtractor();
+        let input = format!("`bug`[code](http://example.net/)");
+        let result = le.find_links(&input);
+        let expected = MarkupLink {
+            target: "http://example.net/".to_string(),
+            line: 1,
+            column: 13,
             source: "".to_string(),
         };
         assert_eq!(vec![expected], result);


### PR DESCRIPTION
This test case demonstrates that mlc currently fails to find a valid link with this markdown:

```
`bug` [code](http://example.net/), link!.
```
