### PR TITLE
Minor things plus clippy warnings

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,13 +1,12 @@
 #[cfg(test)]
-
 #[macro_use]
 extern crate criterion;
 
 use criterion::Criterion;
-use std::fs;
 use mlc::logger;
 use mlc::markup::MarkupType;
 use mlc::Config;
+use std::fs;
 
 fn end_to_end_benchmark() {
     let config = Config {
@@ -25,7 +24,9 @@ fn end_to_end_benchmark() {
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    c.bench_function("End to end benchmark", |b| b.iter(|| end_to_end_benchmark()));
+    c.bench_function("End to end benchmark", |b| {
+        b.iter(|| end_to_end_benchmark())
+    });
 }
 
 criterion_group! {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 use std::path::MAIN_SEPARATOR;
 use wildmatch::WildMatch;
 
+#[must_use]
 pub fn parse_args() -> Config {
     let matches = App::new(crate_name!())
         .arg(

--- a/src/file_traversal.rs
+++ b/src/file_traversal.rs
@@ -23,7 +23,7 @@ pub fn find(config: &Config, result: &mut Vec<MarkupFile>) {
     {
         let f_name = entry.file_name().to_string_lossy();
 
-        if let Some(markup_type) = markup_type(&f_name, &markup_types) {
+        if let Some(markup_type) = markup_type(&f_name, markup_types) {
             let path = entry.path();
             let abs_path = fs::canonicalize(path).expect("Expected path to exist.");
             if ignore_paths.iter().any(|ignore_path| {
@@ -59,7 +59,7 @@ fn markup_type(file: &str, markup_types: &[MarkupType]) -> Option<MarkupType> {
             let mut ext_low = String::from(".");
             ext_low.push_str(&ext.to_lowercase());
             if file_low.ends_with(&ext_low) {
-                return Some(markup_type.clone());
+                return Some(*markup_type);
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,10 +88,7 @@ fn print_result(result: &FinalResult, map: &HashMap<Target, Vec<MarkupLink>>) {
             LinkCheckResult::Ok => {
                 print_helper(link, &"OK".green(), "", false);
             }
-            LinkCheckResult::NotImplemented(msg) => {
-                print_helper(link, &"Warn".yellow(), msg, false);
-            }
-            LinkCheckResult::Warning(msg) => {
+            LinkCheckResult::NotImplemented(msg) | LinkCheckResult::Warning(msg) => {
                 print_helper(link, &"Warn".yellow(), msg, false);
             }
             LinkCheckResult::Ignored(msg) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ fn print_helper(
     error_channel: bool,
 ) {
     let link_str = format!(
-        "[{:^4}] {} ({}, {}) => {}. {}",
+        "[{:^4}] {} ({}, {}) => {} - {}",
         status_code, link.source, link.line, link.column, link.target, msg
     );
     if error_channel {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ struct Target {
 
 fn find_all_links(config: &Config) -> Vec<MarkupLink> {
     let mut files: Vec<MarkupFile> = Vec::new();
-    file_traversal::find(&config, &mut files);
+    file_traversal::find(config, &mut files);
     let mut links = vec![];
     for file in files {
         links.append(&mut link_extractors::link_extractor::find_links(&file));
@@ -86,26 +86,26 @@ fn print_result(result: &FinalResult, map: &HashMap<Target, Vec<MarkupLink>>) {
     for link in &map[&result.target] {
         match &result.result_code {
             LinkCheckResult::Ok => {
-                print_helper(&link, &"OK".green(), "", false);
+                print_helper(link, &"OK".green(), "", false);
             }
             LinkCheckResult::NotImplemented(msg) => {
-                print_helper(&link, &"Warn".yellow(), msg, false);
+                print_helper(link, &"Warn".yellow(), msg, false);
             }
             LinkCheckResult::Warning(msg) => {
-                print_helper(&link, &"Warn".yellow(), msg, false);
+                print_helper(link, &"Warn".yellow(), msg, false);
             }
             LinkCheckResult::Ignored(msg) => {
-                print_helper(&link, &"Skip".green(), msg, false);
+                print_helper(link, &"Skip".green(), msg, false);
             }
             LinkCheckResult::Failed(msg) => {
-                print_helper(&link, &"Err".red(), msg, true);
+                print_helper(link, &"Err".red(), msg, true);
             }
         }
     }
 }
 
 pub async fn run(config: &Config) -> Result<(), ()> {
-    let links = find_all_links(&config);
+    let links = find_all_links(config);
     let mut link_target_groups: HashMap<Target, Vec<MarkupLink>> = HashMap::new();
 
     let mut skipped = 0;
@@ -113,7 +113,7 @@ pub async fn run(config: &Config) -> Result<(), ()> {
     for link in &links {
         if config.ignore_links.iter().any(|m| m.matches(&link.target)) {
             print_helper(
-                &link,
+                link,
                 &"Skip".green(),
                 "Ignore link because of ignore-links option.",
                 false,
@@ -122,7 +122,7 @@ pub async fn run(config: &Config) -> Result<(), ()> {
             continue;
         }
         let link_type = get_link_type(&link.target);
-        let target = resolve_target_link(&link, &link_type, config).await;
+        let target = resolve_target_link(link, &link_type, config).await;
         let t = Target { target, link_type };
         match link_target_groups.get_mut(&t) {
             Some(v) => v.push(link.clone()),
@@ -183,7 +183,7 @@ pub async fn run(config: &Config) -> Result<(), ()> {
                 }
 
                 let result_code =
-                    link_validator::check(&target.target, &target.link_type, &config).await;
+                    link_validator::check(&target.target, &target.link_type, config).await;
 
                 FinalResult {
                     target: target.clone(),
@@ -233,7 +233,9 @@ pub async fn run(config: &Config) -> Result<(), ()> {
     println!("Errors   {}", error_sum);
     println!();
 
-    if !errors.is_empty() {
+    if errors.is_empty() {
+        Ok(())
+    } else {
         eprintln!();
         eprintln!("The following links could not be resolved:");
         println!();
@@ -247,7 +249,5 @@ pub async fn run(config: &Config) -> Result<(), ()> {
         }
         println!();
         Err(())
-    } else {
-        Ok(())
     }
 }

--- a/src/link_extractors/html_link_extractor.rs
+++ b/src/link_extractors/html_link_extractor.rs
@@ -3,6 +3,7 @@ use crate::link_extractors::link_extractor::MarkupLink;
 
 pub struct HtmlLinkExtractor();
 
+#[derive(Clone, Copy, Debug)]
 enum ParserState {
     Text,
     Comment,

--- a/src/link_extractors/html_link_extractor.rs
+++ b/src/link_extractors/html_link_extractor.rs
@@ -83,9 +83,8 @@ impl LinkExtractor for HtmlLinkExtractor {
                                     }
                                     column += 1;
                                 }
-                                let link = (&line_chars[start_col..column])
-                                    .iter()
-                                    .collect::<String>();
+                                let link =
+                                    (&line_chars[start_col..column]).iter().collect::<String>();
                                 result.push(MarkupLink {
                                     column: link_column + 1,
                                     line: link_line + 1,
@@ -126,11 +125,7 @@ mod tests {
         assert!(result.is_empty());
     }
 
-    #[test_case(
-        "<a href=\"https://www.w3schools.com\">Visit W3Schools.com!</a>",
-        1,
-        1
-    )]
+    #[test_case("<a href=\"https://www.w3schools.com\">Visit W3Schools.com!</a>", 1, 1)]
     #[test_case(
         "<a\nhref\n=\n  \"https://www.w3schools.com\">\nVisit W3Schools.com!\n</a>",
         1,

--- a/src/link_extractors/link_extractor.rs
+++ b/src/link_extractors/link_extractor.rs
@@ -4,12 +4,12 @@ use crate::markup::{MarkupFile, MarkupType};
 use std::fmt;
 use std::fs;
 
-/// Links found in markup files
+/// Link found in markup files
 #[derive(PartialEq, Clone)]
 pub struct MarkupLink {
     /// The source file of the link
     pub source: String,
-    /// The target the links points to
+    /// The target the link points to
     pub target: String,
     /// The line number were the link was found
     pub line: usize,

--- a/src/link_extractors/link_extractor.rs
+++ b/src/link_extractors/link_extractor.rs
@@ -27,9 +27,10 @@ impl fmt::Debug for MarkupLink {
     }
 }
 
+#[must_use]
 pub fn find_links(file: &MarkupFile) -> Vec<MarkupLink> {
     let path = &file.path;
-    let link_extractor = link_extractor_factory(&file.markup_type);
+    let link_extractor = link_extractor_factory(file.markup_type);
 
     info!("Scan file at path '{}' for links.", path);
     match fs::read_to_string(path) {
@@ -50,7 +51,7 @@ pub fn find_links(file: &MarkupFile) -> Vec<MarkupLink> {
     }
 }
 
-fn link_extractor_factory(markup_type: &MarkupType) -> Box<dyn LinkExtractor> {
+fn link_extractor_factory(markup_type: MarkupType) -> Box<dyn LinkExtractor> {
     match markup_type {
         MarkupType::Markdown => Box::new(MarkdownLinkExtractor()),
         MarkupType::Html => Box::new(HtmlLinkExtractor()),

--- a/src/link_extractors/markdown_link_extractor.rs
+++ b/src/link_extractors/markdown_link_extractor.rs
@@ -19,7 +19,7 @@ impl LinkExtractor for MarkdownLinkExtractor {
 
         let parser = Parser::new_with_broken_link_callback(text, Options::empty(), Some(callback));
 
-        let line_lengths: Vec<usize> = text.lines().map(|line| line.len()).collect();
+        let line_lengths: Vec<usize> = text.lines().map(str::len).collect();
         let line_column_from_idx = |idx: usize| -> (usize, usize) {
             let mut line = 1;
             let mut column = idx + 1;
@@ -46,7 +46,7 @@ impl LinkExtractor for MarkdownLinkExtractor {
                                 column: line_col.1,
                                 source: String::new(),
                                 target: destination.to_string(),
-                            })
+                            });
                         }
                         _ => (),
                     };

--- a/src/link_validator/file_system.rs
+++ b/src/link_validator/file_system.rs
@@ -63,7 +63,7 @@ pub async fn resolve_target_link(source: &str, target: &str, config: &Config) ->
         .replace('\\', &MAIN_SEPARATOR.to_string());
     if let Some(idx) = normalized_link.find('#') {
         warn!(
-            "Strip everything after #. The chapter part ´{}´ is not checked.",
+            "Strip everything after #. The chapter part '{}' is not checked.",
             &normalized_link[idx..]
         );
         normalized_link = normalized_link[..idx].to_string();
@@ -103,7 +103,7 @@ async fn absolute_target_path(source: &str, target: &PathBuf) -> PathBuf {
         };
         parent.join(new_target)
     } else {
-        target.to_owned()
+        target.clone()
     }
 }
 

--- a/src/link_validator/file_system.rs
+++ b/src/link_validator/file_system.rs
@@ -48,9 +48,9 @@ pub async fn check_filesystem(target: &str, config: &Config) -> LinkCheckResult 
                     }
                 }
             }
-            return LinkCheckResult::Failed("Target not found.".to_string());
+            LinkCheckResult::Failed("Target not found.".to_string())
         } else {
-            return LinkCheckResult::Failed("Target not found.".to_string());
+            LinkCheckResult::Failed("Target not found.".to_string())
         }
     } else {
         LinkCheckResult::Failed("Target filename not found.".to_string())

--- a/src/link_validator/http.rs
+++ b/src/link_validator/http.rs
@@ -9,7 +9,7 @@ use reqwest::StatusCode;
 
 pub async fn check_http(target: &str) -> LinkCheckResult {
     debug!("Check http link target {:?}", target);
-    let url = reqwest::Url::parse(&target).expect("URL of unknown type");
+    let url = reqwest::Url::parse(target).expect("URL of unknown type");
 
     match http_request(&url).await {
         Ok(response) => response,

--- a/src/link_validator/http.rs
+++ b/src/link_validator/http.rs
@@ -30,7 +30,7 @@ async fn http_request(url: &reqwest::Url) -> reqwest::Result<LinkCheckResult> {
         static ref CLIENT: Client = Client::new();
     }
 
-    fn status_to_string(status: &StatusCode) -> String {
+    fn status_to_string(status: StatusCode) -> String {
         format!(
             "{} - {}",
             status.as_str(),
@@ -53,7 +53,7 @@ async fn http_request(url: &reqwest::Url) -> reqwest::Result<LinkCheckResult> {
     if status.is_success() {
         Ok(LinkCheckResult::Ok)
     } else if status.is_redirection() {
-        Ok(LinkCheckResult::Warning(status_to_string(&status)))
+        Ok(LinkCheckResult::Warning(status_to_string(status)))
     } else {
         debug!("Got the status code {:?}. Retry with get-request.", status);
         let get_request = Request::new(Method::GET, url.clone());
@@ -62,7 +62,7 @@ async fn http_request(url: &reqwest::Url) -> reqwest::Result<LinkCheckResult> {
         if status.is_success() {
             Ok(LinkCheckResult::Ok)
         } else {
-            Ok(LinkCheckResult::Failed(status_to_string(&status)))
+            Ok(LinkCheckResult::Failed(status_to_string(status)))
         }
     }
 }

--- a/src/link_validator/link_type.rs
+++ b/src/link_validator/link_type.rs
@@ -12,6 +12,7 @@ pub enum LinkType {
     UnknownUrlSchema,
 }
 
+#[must_use]
 pub fn get_link_type(link: &str) -> LinkType {
     lazy_static! {
         static ref FILE_SYSTEM_REGEX: Regex =
@@ -29,15 +30,13 @@ pub fn get_link_type(link: &str) -> LinkType {
     if let Ok(url) = Url::parse(link) {
         let scheme = url.scheme();
         debug!("Link {} is a URL type with scheme {}", link, scheme);
-        match scheme {
-            "http" => return LinkType::Http,
-            "https" => return LinkType::Http,
-            "ftp" => return LinkType::Ftp,
-            "ftps" => return LinkType::Ftp,
-            "mailto" => return LinkType::Mail,
-            "file" => return LinkType::FileSystem,
-            _ => return LinkType::UnknownUrlSchema,
-        }
+        return match scheme {
+            "http" | "https" => LinkType::Http,
+            "ftp" | "ftps" => LinkType::Ftp,
+            "mailto" => LinkType::Mail,
+            "file" => LinkType::FileSystem,
+            _ => LinkType::UnknownUrlSchema,
+        };
     }
     LinkType::UnknownUrlSchema
 }

--- a/src/link_validator/link_type.rs
+++ b/src/link_validator/link_type.rs
@@ -3,7 +3,7 @@ extern crate url;
 use self::url::Url;
 use regex::Regex;
 
-#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum LinkType {
     Http,
     Ftp,

--- a/src/link_validator/link_type.rs
+++ b/src/link_validator/link_type.rs
@@ -19,14 +19,14 @@ pub fn get_link_type(link: &str) -> LinkType {
     }
 
     if FILE_SYSTEM_REGEX.is_match(link) || !link.contains(':') {
-        if link.contains('@') {
-            return LinkType::Mail;
+        return if link.contains('@') {
+            LinkType::Mail
         } else {
-            return LinkType::FileSystem;
-        }
+            LinkType::FileSystem
+        };
     }
 
-    if let Ok(url) = Url::parse(&link) {
+    if let Ok(url) = Url::parse(link) {
         let scheme = url.scheme();
         debug!("Link {} is a URL type with scheme {}", link, scheme);
         match scheme {

--- a/src/link_validator/mod.rs
+++ b/src/link_validator/mod.rs
@@ -28,7 +28,7 @@ pub async fn resolve_target_link(
     config: &Config,
 ) -> String {
     if link_type == &LinkType::FileSystem {
-        file_system::resolve_target_link(&link.source, &link.target, &config).await
+        file_system::resolve_target_link(&link.source, &link.target, config).await
     } else {
         link.target.to_string()
     }
@@ -54,6 +54,6 @@ pub async fn check(link_target: &str, link_type: &LinkType, config: &Config) -> 
                 check_http(link_target).await
             }
         }
-        LinkType::FileSystem => check_filesystem(&link_target, &config).await,
+        LinkType::FileSystem => check_filesystem(link_target, config).await,
     }
 }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -31,7 +31,7 @@ pub fn init(log_level: &LogLevel) {
         ColorChoice::Auto,
     )]);
     if err.is_err() {
-        panic!("Failied to init logger! Error: {:?}", err)
+        panic!("Failied to init logger! Error: {:?}", err);
     }
-    debug!("Initialized logging")
+    debug!("Initialized logging");
 }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -3,7 +3,7 @@ extern crate simplelog;
 use simplelog::*;
 
 arg_enum! {
-    #[derive(Debug)]
+    #[derive(Debug, Clone, Copy)]
     pub enum LogLevel {
         Info,
         Warn,

--- a/src/markup.rs
+++ b/src/markup.rs
@@ -39,11 +39,7 @@ impl MarkupType {
                 "text".to_string(),
                 "rmd".to_string(),
             ],
-            MarkupType::Html => vec![
-                "htm".to_string(),
-                "html".to_string(),
-                "xhtml".to_string(),
-                ],
+            MarkupType::Html => vec!["htm".to_string(), "html".to_string(), "xhtml".to_string()],
         }
     }
 }

--- a/src/markup.rs
+++ b/src/markup.rs
@@ -25,6 +25,7 @@ impl FromStr for MarkupType {
 }
 
 impl MarkupType {
+    #[must_use]
     pub fn file_extensions(&self) -> Vec<String> {
         match self {
             MarkupType::Markdown => vec![

--- a/src/markup.rs
+++ b/src/markup.rs
@@ -6,7 +6,7 @@ pub struct MarkupFile {
     pub path: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum MarkupType {
     Markdown,
     Html,

--- a/src/markup.rs
+++ b/src/markup.rs
@@ -39,7 +39,11 @@ impl MarkupType {
                 "text".to_string(),
                 "rmd".to_string(),
             ],
-            MarkupType::Html => vec!["html".to_string(), "xhtml".to_string()],
+            MarkupType::Html => vec![
+                "htm".to_string(),
+                "html".to_string(),
+                "xhtml".to_string(),
+                ],
         }
     }
 }

--- a/tests/helper/mod.rs
+++ b/tests/helper/mod.rs
@@ -1,14 +1,13 @@
 #[cfg(test)]
-
 use std::path::{Path, PathBuf};
 
-pub fn benches_dir()-> PathBuf {
+pub fn benches_dir() -> PathBuf {
     Path::new(file!())
-    .parent()
-    .unwrap()
-    .parent()
-    .unwrap()
-    .parent()
-    .unwrap()
-    .join("benches")
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("benches")
 }

--- a/tests/markdown_files.rs
+++ b/tests/markdown_files.rs
@@ -2,7 +2,6 @@
 use mlc::link_extractors::link_extractor::find_links;
 use mlc::markup::{MarkupFile, MarkupType};
 
-
 #[test]
 fn no_links() {
     let path = "./benches/benchmark/markdown/no_links/no_links.md".to_string();


### PR DESCRIPTION
* Adds ".htm" as a known HTML file extension (common@Microsoft)
* Makes link-printout less confusing
* Marks some simple enums with Copy
* Fixes clippy warnings