### PR TITLE
Disable automatic redirects so that redirections are treated as warnings

### DIFF
--- a/src/link_validator/http.rs
+++ b/src/link_validator/http.rs
@@ -4,6 +4,7 @@ use reqwest::header::ACCEPT;
 use reqwest::header::USER_AGENT;
 use reqwest::Client;
 use reqwest::Method;
+use reqwest::redirect::Policy;
 use reqwest::Request;
 use reqwest::StatusCode;
 
@@ -27,7 +28,10 @@ fn new_request(method: Method, url: &reqwest::Url) -> Request {
 
 async fn http_request(url: &reqwest::Url) -> reqwest::Result<LinkCheckResult> {
     lazy_static! {
-        static ref CLIENT: Client = Client::new();
+        static ref CLIENT: Client = Client::builder()
+            .redirect(Policy::none())
+            .build()
+            .unwrap();
     }
 
     fn status_to_string(status: StatusCode) -> String {

--- a/src/link_validator/http.rs
+++ b/src/link_validator/http.rs
@@ -77,10 +77,16 @@ mod test {
 
     #[tokio::test]
     async fn check_http_is_available() {
-        let result = check_http("http://gitlab.com/becheran/mlc").await;
+        let result = check_http("https://gitlab.com/becheran/mlc").await;
         assert_eq!(result, LinkCheckResult::Ok);
     }
-    
+
+    #[tokio::test]
+    async fn check_http_is_redirection() {
+        let result = check_http("http://gitlab.com/becheran/mlc").await;
+        assert_eq!(result, LinkCheckResult::Warning("301 - Moved Permanently".to_string()));
+    }
+
     #[tokio::test]
     async fn check_https_crates_io_available() {
         let result = check_http("https://crates.io").await;
@@ -89,8 +95,14 @@ mod test {
 
     #[tokio::test]
     async fn check_http_request_with_hash() {
-        let result = check_http("http://gitlab.com/becheran/mlc#bla").await;
+        let result = check_http("https://gitlab.com/becheran/mlc#bla").await;
         assert_eq!(result, LinkCheckResult::Ok);
+    }
+
+    #[tokio::test]
+    async fn check_http_request_redirection_with_hash() {
+        let result = check_http("http://gitlab.com/becheran/mlc#bla").await;
+        assert_eq!(result, LinkCheckResult::Warning("301 - Moved Permanently".to_string()));
     }
 
     #[tokio::test]


### PR DESCRIPTION
On `http.rs`:

https://github.com/becheran/mlc/blob/0e2a60ae0f799cf124aa9473d6df2d0231bcf3db/src/link_validator/http.rs#L55-L56

We're checking if the status is a redirection, to treat it as a warning. However, as the client we're creating doesn't have a redirect policy, it's following redirection (that can be seen when enabling debug mode).

The caveat here is that if there's a 301 to a 404, we today report that as an error. Now, that would be treated as a warning.

I'm not sure if this should live behind an extra cli argument.

This relates to #55