### PR TITLE
Fix panic due to arg rename

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -105,7 +105,7 @@ pub fn parse_args() -> Config {
         markup_types = types.map(|x| x.parse().unwrap()).collect();
     }
 
-    let no_web_links = matches.is_present("no_web_links");
+    let no_web_links = matches.is_present("offline");
 
     let match_file_extension = matches.is_present("match-file-extension");
 


### PR DESCRIPTION
On https://github.com/becheran/mlc/commit/cee03ebeddea00e69c9e2fbb6c181698e00a3c1a `no-web-links` was renamed to `offline`, but that causes a panic when doing `matches.is_present("no_web_links")`.

This PR fixes that by just doing `matches.is_present("offline")`