### PR TITLE
Allow multiple values for ignore_path and ignore_links

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -42,7 +42,8 @@ pub fn parse_args() -> Config {
                 .long("ignore-path")
                 .help("List of files and directories which will not be checked")
                 .takes_value(true)
-                .required(false),
+                .required(false)
+                .multiple_values(true),
         )
         .arg(
             Arg::with_name("ignore_links")
@@ -50,7 +51,8 @@ pub fn parse_args() -> Config {
                 .short('i')
                 .help("List of links which will not be checked")
                 .takes_value(true)
-                .required(false),
+                .required(false)
+                .multiple_values(true),
         )
         .arg(
             Arg::with_name("markup_types")


### PR DESCRIPTION
It's very likely that I missed how to do this, if that's the case I'll tweak the docs. On this PR I'm adding `multiple_values(true)` to both `ignore-path` and `ignore_links`, so that it can ignore multiple paths and multiple links.

This PR lets you use `mlc` in these scenarios, previously unsupported:

```
./mlc _site --ignore-links "https://www.linkedin.com/*" "https://www.sec.gov/*"                                           

++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+                                                          +
+        markup link checker - mlc v0.15.5-alpha.0         +
+                                                          +
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

error: Found argument 'https://www.sec.gov/*' which wasn't expected, or isn't valid in this context
```

```
./mlc _site --ignore-path "_site/2019" "_site/webcast" 

++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+                                                          +
+        markup link checker - mlc v0.15.5-alpha.0         +
+                                                          +
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

error: Found argument '_site/webcast' which wasn't expected, or isn't valid in this context
```