### PR TITLE
build: strip symbols from github binaries

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,7 +51,7 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Build
-        run: cargo build --release --verbose --target=x86_64-unknown-linux-musl
+        run: cargo rustc --release --verbose --target=x86_64-unknown-linux-musl --bin mlc -- -C prefer-dynamic=no -C strip=symbols
       - uses: actions/upload-artifact@v3
         with:
           name: linux
@@ -72,7 +72,7 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Build
-        run: cargo build --verbose --release
+        run: cargo rustc --verbose --release --bin mlc -- -C prefer-dynamic=no -C strip=symbols
       - uses: actions/upload-artifact@v3
         with:
           name: windows


### PR DESCRIPTION
Strip symbols from mlc Linux and Windows binaries built by Github actions to produce smaller binaries.
https://doc.rust-lang.org/rustc/codegen-options/index.html#strip