### PR TITLE
Use root path in file traversal

### DIFF
--- a/src/file_traversal.rs
+++ b/src/file_traversal.rs
@@ -28,11 +28,11 @@ pub fn find(config: &Config, result: &mut Vec<MarkupFile>) {
     };
 
     info!(
-        "Search for files of markup types '{:?}' in directory '{:?}'",
-        markup_types, root
+        "Search for files of markup types {:?} in directory {:?}",
+        markup_types, relative_root 
     );
 
-    for entry in WalkDir::new(root)
+    for entry in WalkDir::new(relative_root)
         .follow_links(false)
         .into_iter()
         .filter_map(Result::ok)

--- a/src/file_traversal.rs
+++ b/src/file_traversal.rs
@@ -6,21 +6,7 @@ use std::fs;
 use walkdir::WalkDir;
 
 pub fn find(config: &Config, result: &mut Vec<MarkupFile>) {
-    let mut relative_root = config.directory.to_owned();
-
-    if let Some(root) = &config.optional.root_dir {
-        relative_root = root
-            .join(&relative_root)
-            .canonicalize()
-            .map_err(|e| {
-                eprintln!(
-                    "Relative path from privided root {:?} is malformed: {:?} --- {}",
-                    root, relative_root, e
-                );
-                std::process::exit(1);
-            })
-            .unwrap();
-    }
+    let directory = &config.directory;
 
     let markup_types = match &config.optional.markup_types {
         Some(t) => t,
@@ -29,10 +15,10 @@ pub fn find(config: &Config, result: &mut Vec<MarkupFile>) {
 
     info!(
         "Search for files of markup types {:?} in directory {:?}",
-        markup_types, relative_root 
+        markup_types, directory
     );
 
-    for entry in WalkDir::new(relative_root)
+    for entry in WalkDir::new(directory)
         .follow_links(false)
         .into_iter()
         .filter_map(Result::ok)

--- a/src/file_traversal.rs
+++ b/src/file_traversal.rs
@@ -14,8 +14,8 @@ pub fn find(config: &Config, result: &mut Vec<MarkupFile>) {
             .canonicalize()
             .map_err(|e| {
                 eprintln!(
-                    "Relative path from privided root is malformed: {:?} --- {}",
-                    relative_root, e
+                    "Relative path from privided root {:?} is malformed: {:?} --- {}",
+                    root, relative_root, e
                 );
                 std::process::exit(1);
             })

--- a/src/file_traversal.rs
+++ b/src/file_traversal.rs
@@ -6,7 +6,22 @@ use std::fs;
 use walkdir::WalkDir;
 
 pub fn find(config: &Config, result: &mut Vec<MarkupFile>) {
-    let root = &config.directory;
+    let mut relative_root = config.directory.to_owned();
+
+    if let Some(root) = &config.optional.root_dir {
+        relative_root = root
+            .join(&relative_root)
+            .canonicalize()
+            .map_err(|e| {
+                eprintln!(
+                    "Relative path from privided root is malformed: {:?} --- {}",
+                    relative_root, e
+                );
+                std::process::exit(1);
+            })
+            .unwrap();
+    }
+
     let markup_types = match &config.optional.markup_types {
         Some(t) => t,
         None => panic!("Bug! markup_types must be set"),


### PR DESCRIPTION
Root path used if given, appending relative directory given in CLI if present.

~~Perhaps not the best handling of errors, as the root (if given in CLI or in config) will be used as the base path for the CLI path given `directory` and may be confusing if you don't realize the root is set in a config file, and the error informs you of some path you _think_ should exist relative to your `pwd` path... :thinking:~~

More verbose eprint provided :+1: 

This doesn't pickup the config from a provided `root` path, that I would expect it to though.


closes #78 