### PR TITLE
Do Not Warn for Redirects to Given Patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ All optional arguments which can be passed via the command line can also be conf
 ``` toml
 # Print debug information to console
 debug = true
+# Do not warn for links which redirect to the given URL
+do-not-warn-for-redirect-to=["http*://crates.io*"]
 # Do not check web links
 offline = true
 # Check the exact file extension when searching for a file

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The following arguments are available:
 | `<directory>`    |       | Only positional argument. Path to directory which shall be checked with all sub-dirs. Can also be a specific filename which shall be checked. |
 | `--help`         | `-h`  | Print help |
 | `--debug`        | `-d`  | Show verbose debug information |
+| `--do-not-warn-for-redirect-to` | | Do not warn for links which redirect to the given URL. Allows the same link format as `--ignore-links`. For example, `--do-not-warn-for-redirect-to "http*://crates.io*"` will not warn for links which redirect to the `crates.io` website. |
 | `--offline`      | `-o`  | Do not check any web links. Renamed from `--no-web-links` which is still an alias for downwards compatibility |
 | `--match-file-extension` | `-e`  | Set the flag, if the file extension shall be checked as well. For example the following markup link `[link](dir/file)` matches if for example a file called `file.md` exists in `dir`, but would fail when the `--match-file-extension` flag is set. |
 | `--version`      | `-V` | Print current version of mlc |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,6 +29,13 @@ pub fn parse_args() -> Config {
         .arg(arg!(-o --offline "Do not check web links")
             .alias("no-web-links")
             .required(false))
+        .arg(Arg::new("do-not-warn-for-redirect-to")
+            .long("do-not-warn-for-redirect-to")
+            .value_name("LINKS")
+            .value_delimiter(',')
+            .action(ArgAction::Append)
+            .help("Comma separated list of links which will be ignored")
+            .required(false))
         .arg(Arg::new("match-file-extension")
             .long("match-file-extension")
             .short('e')
@@ -86,6 +93,10 @@ pub fn parse_args() -> Config {
 
     if matches.get_flag("debug") {
         opt.debug = Some(true);
+    }
+    
+    if let Some(do_not_warn_for_redirect_to) = matches.get_many::<String>("do-not-warn-for-redirect-to") {
+        opt.do_not_warn_for_redirect_to = Some(do_not_warn_for_redirect_to.map(|x| x.to_string()).collect());
     }
 
     if let Some(throttle_str) = matches.get_one::<String>("throttle") {

--- a/src/link_validator/mod.rs
+++ b/src/link_validator/mod.rs
@@ -12,6 +12,7 @@ use mail::check_mail;
 
 pub use link_type::get_link_type;
 pub use link_type::LinkType;
+use wildmatch::WildMatch;
 
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub enum LinkCheckResult {
@@ -34,7 +35,7 @@ pub async fn resolve_target_link(
     }
 }
 
-pub async fn check(link_target: &str, link_type: &LinkType, config: &Config) -> LinkCheckResult {
+pub async fn check(link_target: &str, link_type: &LinkType, config: &Config, do_not_warn_for_redirect_to: &Vec<WildMatch>) -> LinkCheckResult {
     info!("Check link {}.", &link_target);
     match link_type {
         LinkType::Ftp => LinkCheckResult::NotImplemented(format!(
@@ -51,7 +52,7 @@ pub async fn check(link_target: &str, link_type: &LinkType, config: &Config) -> 
                     "Ignore web link because of the offline flag.".to_string(),
                 )
             } else {
-                check_http(link_target).await
+                check_http(link_target, do_not_warn_for_redirect_to).await
             }
         }
         LinkType::FileSystem => check_filesystem(link_target, config).await,

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -13,6 +13,7 @@ async fn end_to_end() {
         directory: benches_dir().join("benchmark"),
         optional: OptionalConfig {
             debug: None,
+            do_not_warn_for_redirect_to: None,
             markup_types: Some(vec![MarkupType::Markdown]),
             offline: None,
             match_file_extension: None,
@@ -37,6 +38,7 @@ async fn end_to_end_different_root() {
         directory: test_files.clone(),
         optional: OptionalConfig {
             debug: Some(true),
+            do_not_warn_for_redirect_to: None,
             markup_types: Some(vec![MarkupType::Markdown]),
             offline: None,
             match_file_extension: None,


### PR DESCRIPTION
As proposed in #84, this adds the new option `--do-not-warn-for-redirect-to` which allows to mute warnings for redirections if they lead to an URL which matches the specified pattern. 

I've used my (rudimentary) understanding of Rust to implement this option roughly mirrored to the existing `--ignore-links` option, so feel free to suggest any kind of improvements/problems which my solution has (I hope my choice of using `Arc` to share the `do_not_warn_for_redirect_to` vector was at least not an utter failure)! 

The PR includes three new tests for `check_http` and adds the option to the main Readme. 
For now, I haven't changed the [CHANGELOG.md](https://github.com/becheran/mlc/blob/master/CHANGELOG.md) because I am not sure if I am even supposed to do that.

