### PR TITLE
Move error summary output to stdout

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -329,8 +329,8 @@ pub async fn run(config: &Config) -> Result<(), ()> {
     if errors.is_empty() {
         Ok(())
     } else {
-        eprintln!();
-        eprintln!("The following links could not be resolved:");
+        println!();
+        println!("The following links could not be resolved:");
         println!();
         for res in errors {
             for link in &link_target_groups[&res.target] {


### PR DESCRIPTION
Modifies the summary printed at the end to be entirely in stdout instead of mixed between stderr and stdout. Without this commit, suppressing stdout output or capturing stderr output for logs would result in "The following links could not be resolved:" being printed without the list of broken links (which should be the same as the stderr output.)

For example, on master:

```console
$ ./mlc ~/bitcoin --offline --root-dir ~/bitcoin > /dev/null
[Err ] /home/USER/bitcoin/doc/README_doxygen.md (14, 54) => namespaces.html - Target filename not found.
[Err ] /home/USER/bitcoin/doc/README_doxygen.md (14, 109) => classes.html - Target filename not found.
[Err ] /home/USER/bitcoin/doc/README_doxygen.md (14, 5) => modules.html - Target filename not found.
[Err ] /home/USER/bitcoin/doc/README_doxygen.md (14, 161) => files.html - Target filename not found.
[Err ] /home/USER/bitcoin/test/README.md (335, 19) => /test/functional/blzr - Target not found.
[Err ] /home/USER/bitcoin/src/secp256k1/doc/release-process.md (37, 12) => /tools/check-abi.sh - Target filename not found.

The following links could not be resolved:
$
```

On this branch:

```console
$ ./mlc ~/bitcoin --offline --root-dir ~/bitcoin > /dev/null
[Err ] /home/USER/bitcoin/src/secp256k1/doc/release-process.md (37, 12) => /tools/check-abi.sh - Target filename not found.
[Err ] /home/USER/bitcoin/test/README.md (335, 19) => /test/functional/blzr - Target not found.
[Err ] /home/USER/bitcoin/doc/README_doxygen.md (14, 54) => namespaces.html - Target filename not found.
[Err ] /home/USER/bitcoin/doc/README_doxygen.md (14, 5) => modules.html - Target filename not found.
[Err ] /home/USER/bitcoin/doc/README_doxygen.md (14, 109) => classes.html - Target filename not found.
[Err ] /home/USER/bitcoin/doc/README_doxygen.md (14, 161) => files.html - Target filename not found.
$ 