### PR TITLE
fix: Include untracked files with --gitignore option

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ The following arguments are available:
 | `--version`      | `-V` | Print current version of mlc |
 | `--ignore-path`  | `-p` | Comma separated list of directories or files which shall be ignored. For example  |
 | `--gitignore`    | `-g` | Ignore all files currently ignored by git (requires `git` binary to be available on $PATH). |
+| `--gituntracked` | `-u` | Ignore all files currently untracked by git (requires `git` binary to be available on $PATH). |
 | `--ignore-links` | `-i` | Comma separated list of links which shall be ignored. Use simple `?` and `*` wildcards. For example `--ignore-links "http*://crates.io*"` will skip all links to the crates.io website. See the [used lib](https://github.com/becheran/wildmatch) for more information.  |
 | `--markup-types` | `-t` | Comma separated list list of markup types which shall be checked [possible values: md, html] |
 | `--root-dir`     | `-r` | All links to the file system starting with a slash on linux or backslash on windows will use another virtual root dir. For example the link in a file `[link](/dir/other/file.md)` checked with the cli arg `--root-dir /env/another/dir` will let *mlc* check the existence of `/env/another/dir/dir/other/file.md`. |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -105,6 +105,15 @@ pub fn parse_args() -> Config {
                 .action(ArgAction::SetTrue)
                 .required(false),
         )
+        .arg(
+            Arg::new("gituntracked")
+                .long("gituntracked")
+                .short('u')
+                .value_name("GITUNTRACKED")
+                .help("Ignore all files untracked by git")
+                .action(ArgAction::SetTrue)
+                .required(false),
+        )
         .get_matches();
 
     let default_dir = format!(".{}", &MAIN_SEPARATOR);
@@ -173,6 +182,10 @@ pub fn parse_args() -> Config {
 
     if matches.get_flag("gitignore") {
         opt.gitignore = Some(true);
+    }
+
+    if matches.get_flag("gituntracked") {
+        opt.gituntracked = Some(true);
     }
 
     if let Some(root_dir) = matches.get_one::<String>("root-dir") {

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -25,6 +25,7 @@ async fn end_to_end() {
             ]),
             root_dir: None,
             gitignore: None,
+            gituntracked: None,
         },
     };
     if let Err(e) = mlc::run(&config).await {
@@ -48,6 +49,7 @@ async fn end_to_end_different_root() {
             throttle: None,
             root_dir: Some(test_files),
             gitignore: None,
+            gituntracked: None,
         },
     };
     if let Err(e) = mlc::run(&config).await {


### PR DESCRIPTION
This adds a new flag `--gituntracked` which will ignore files that are untracked by git. This could include generated content or build artifacts.

This is implemented seperately from `--gitignore` to provide more granularity over which files will be ignored.