### PR TITLE
Add csv file option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Types for Changes:
 
 ## [Unreleased] - ReleaseDate
 
+- Add csv file output [#40](https://github.com/becheran/mlc/issues/40)
+
 ## [0.21.0] - 2025-02-08
 
 - Fix do not log warnings #100

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ The following arguments are available:
 | `--markup-types` | `-t` | Comma separated list list of markup types which shall be checked. Possible values: `md`, `html` |
 | `--root-dir`     | `-r` | All links to the file system starting with a slash on linux or backslash on windows will use another virtual root dir. For example the link in a file `[link](/dir/other/file.md)` checked with the cli arg `--root-dir /env/another/dir` will let *mlc* check the existence of `/env/another/dir/dir/other/file.md`. |
 | `--throttle`     | `-T` | Number of milliseconds to wait in between web requests to the same host. Default is zero which means no throttling. Set this if you need to slow down the web request frequency to avoid `429 - Too Many Requests` responses. For example with `--throttle 15`, between each http check to the same host, 15 ms will be waited. Note that this setting can slow down the link checker. |
+| `--csv`          |      | Path to csv file which contains all failed requests in the format `source,line,column,target` |
 
 All optional arguments which can be passed via the command line can also be configured via the `.mlc.toml` config file in the working directory:
 

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -6,6 +6,7 @@ use mlc::markup::MarkupType;
 use mlc::Config;
 use mlc::OptionalConfig;
 use std::fs;
+use std::path::MAIN_SEPARATOR;
 
 #[tokio::test]
 async fn end_to_end() {
@@ -26,16 +27,18 @@ async fn end_to_end() {
             root_dir: None,
             gitignore: None,
             gituntracked: None,
+            csv_file: None,
         },
     };
     if let Err(e) = mlc::run(&config).await {
-        panic!("Test with custom root failed. {:?}", e);
+        panic!("Test failed. {:?}", e);
     }
 }
 
 #[tokio::test]
 async fn end_to_end_different_root() {
     let test_files = benches_dir().join("different_root");
+    let csv_output = std::env::temp_dir().join("mlc_test_output.csv");
     let config = Config {
         directory: test_files.clone(),
         optional: OptionalConfig {
@@ -50,9 +53,54 @@ async fn end_to_end_different_root() {
             root_dir: Some(test_files),
             gitignore: None,
             gituntracked: None,
+            csv_file: Some(csv_output.clone()),
         },
     };
     if let Err(e) = mlc::run(&config).await {
         panic!("Test with custom root failed. {:?}", e);
+    } else {
+        // Check if the CSV file was created, but is empty except for the header
+        let content = fs::read_to_string(csv_output).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0], "source,line,column,target");
+    }
+}
+
+#[tokio::test]
+async fn end_to_end_write_csv_file() {
+    let csv_output = std::env::temp_dir().join("mlc_test_output.csv");
+    let config = Config {
+        directory: benches_dir().join("benchmark/markdown/ignore_me.md"),
+        optional: OptionalConfig {
+            debug: None,
+            do_not_warn_for_redirect_to: None,
+            markup_types: Some(vec![MarkupType::Markdown]),
+            offline: None,
+            match_file_extension: None,
+            throttle: None,
+            ignore_links: None,
+            ignore_path: None,
+            root_dir: None,
+            gitignore: None,
+            gituntracked: None,
+            csv_file: Some(csv_output.clone()),
+        },
+    };
+    if let Err(_) = mlc::run(&config).await {
+        let content = fs::read_to_string(csv_output).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 4);
+        assert_eq!(lines[0], "source,line,column,target");
+        for i in 1..lines.len() {
+            assert_eq!(
+                lines[i],
+                &format!(
+                    "benches{MAIN_SEPARATOR}benchmark/markdown/ignore_me.md,{i},1,broken_Link",
+                )
+            );
+        }
+    } else {
+        panic!("Should have detected errors");
     }
 }


### PR DESCRIPTION
Add possibility to set csv file as output which contains a list of all failed links. See #40 

@xxxserxxx would the implementation solve your issue? Is listing of all failed check in a CSV file good enough for your usecase or would you need additional fields?